### PR TITLE
chore: Upgrade terraform required version to 1.3+

### DIFF
--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = "~> 16.3"
+      version = "~> 15.0"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = "~> 15.0"
+      version = "3.11.1"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.1.6"
+  required_version = ">=1.3"
 
   backend "remote" {
     hostname     = "app.terraform.io"

--- a/modules/gitlab-group-module/versions.tf
+++ b/modules/gitlab-group-module/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = "~>16.3"
+      version = "3.11.1"
     }
   }
 }

--- a/modules/gitlab-group-module/versions.tf
+++ b/modules/gitlab-group-module/versions.tf
@@ -1,7 +1,5 @@
 terraform {
-  required_version = ">=1.1.6"
-
-  experiments = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 
   required_providers {
     gitlab = {

--- a/modules/gitlab-project-module/versions.tf
+++ b/modules/gitlab-project-module/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = "~> 16.3"
+      version = "3.11.1"
     }
   }
 }

--- a/modules/gitlab-project-module/versions.tf
+++ b/modules/gitlab-project-module/versions.tf
@@ -1,7 +1,5 @@
 terraform {
-  required_version = ">=1.1.6"
-
-  experiments = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 
   required_providers {
     gitlab = {

--- a/modules/gitlab-user-module/versions.tf
+++ b/modules/gitlab-user-module/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = "~> 16.3"
+      version = "3.11.1"
     }
   }
 }

--- a/modules/gitlab-user-module/versions.tf
+++ b/modules/gitlab-user-module/versions.tf
@@ -1,7 +1,5 @@
 terraform {
-  required_version = ">=1.1.6"
-
-  experiments = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 
   required_providers {
     gitlab = {


### PR DESCRIPTION
Upgrade terraform required version to 1.3+ and remove [optional attributes experimental feature](https://developer.hashicorp.com/terraform/language/v1.3.x/upgrade-guides#concluding-the-optional-attributes-experiment)
